### PR TITLE
Added Ocean Beach (SF) and Pleasure Point

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,6 +21,22 @@ spots = [
     msw_id: 2642,
   },
   {
+    name: 'Ocean Beach (SF)',
+    lat: 37.768256511796238,
+    lon: -122.51347658831379,
+    surfline_id: 4127,
+    msw_id: 255,
+    spitcast_id: 114
+  },
+  {
+    name: 'Pleasure Point',
+    lat: 36.954087622045307,
+    lon: -121.9716900628907,
+    surfline_id: 4190,
+    msw_id: 644,
+    spitcast_id: 1
+  },
+  {
     name: 'Zeros',
     lat: 34.041956,
     lon: -118.91593,


### PR DESCRIPTION
Ocean Beach (San Francisco) and Pleasure Point (Santa Cruz) added. For Ocean Beach, Surfline actually has one overall forecast, another one for north OB and one for south OB - I chose the overall forecast. Magicseaweed only has one overall forecast for OB. Spitcast has a North and South OB forecast, so I chose the North one, as the spots are so close together it doesn't really make much of a difference. It's more about where the good sandbanks are at any given time. For Pleasure Point everything is straightforward. Nice project!